### PR TITLE
Fix edge editing: performance, save, and positioning

### DIFF
--- a/src/lib/gesture-machine/gesture-helpers.ts
+++ b/src/lib/gesture-machine/gesture-helpers.ts
@@ -221,8 +221,15 @@ export function createGestureHelpers(controller: CanvasController) {
       const start = ctx.draft.startPositions.get(id);
       el.x = start.x + dx;
       el.y = start.y + dy;
+      // Update each element individually for better performance
+      controller.updateElementNode(
+        controller.elementNodesMap[el.id],
+        el,
+        controller.isElementSelected(el.id),
+        true
+      );
     });
-    controller.requestRender();
+    controller.requestEdgeUpdate();
   }
 
     /* ---------------- group resize (single-handle drag) ---------------- */
@@ -446,10 +453,30 @@ export function createGestureHelpers(controller: CanvasController) {
 
   function editEdgeLabel(_ctx: GestureContext, ev: GestureEvent) {
     const edgeId = ev.edgeId!;
-    const screenXY = ev.xy
     const edge = controller.findEdgeElementById!(edgeId);
     if (!edge) return;
-    const pt = controller.screenToCanvas(screenXY.x, screenXY.y);
+
+    // Calculate the midpoint of the edge for better positioning
+    const sourceEl = controller.findElementById(edge.source);
+    const targetEl = controller.findElementById(edge.target);
+
+    let pt;
+    if (sourceEl && targetEl) {
+      // Position the edit-prompt at the midpoint between source and target
+      const sourceCenterX = sourceEl.x + (sourceEl.width * (sourceEl.scale || 1)) / 2;
+      const sourceCenterY = sourceEl.y + (sourceEl.height * (sourceEl.scale || 1)) / 2;
+      const targetCenterX = targetEl.x + (targetEl.width * (targetEl.scale || 1)) / 2;
+      const targetCenterY = targetEl.y + (targetEl.height * (targetEl.scale || 1)) / 2;
+
+      pt = {
+        x: (sourceCenterX + targetCenterX) / 2,
+        y: (sourceCenterY + targetCenterY) / 2
+      };
+    } else {
+      // Fallback to click position if elements not found
+      pt = controller.screenToCanvas(ev.xy.x, ev.xy.y);
+    }
+
     const editId = controller.createNewElement(
       pt.x, pt.y, 'edit-prompt',
       edge.label || '',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1008,17 +1008,21 @@ ${script.getAttribute('src')}`);
                 const target = this.findElementOrEdgeById(el.target);
                 if (target) {
                     console.log(`[DEBUG] Saving edit prompt content to [${target.id}] as property [${el.property}]. with value: "${val}"`, target, el);
-                    if (target) {
-                        target[el.property] = val;
-                        this.requestEdgeUpdate();
-                        saveCanvas(this.canvasState);
-                    }
+                    target[el.property] = val;
+                    this.requestEdgeUpdate();
+                    saveCanvas(this.canvasState);
                 }
+                // Remove the edit-prompt element after saving
                 this.canvasState.elements = this.canvasState.elements.filter(e => e.id !== el.id);
+                // Remove the meta edge connecting edit-prompt to the target
+                this.canvasState.edges = this.canvasState.edges.filter(e => e.source !== el.id && e.target !== el.id);
                 this.requestRender();
             };
             cancelBtn.onclick = () => {
+                // Remove the edit-prompt element
                 this.canvasState.elements = this.canvasState.elements.filter(e => e.id !== el.id);
+                // Remove the meta edge connecting edit-prompt to the target
+                this.canvasState.edges = this.canvasState.edges.filter(e => e.source !== el.id && e.target !== el.id);
                 this.requestRender();
                 saveCanvas(this.canvasState);
             };


### PR DESCRIPTION
Fixes three issues with edge editing:

1. **Performance:** Optimized drag behavior by updating elements individually instead of full re-render
2. **Save functionality:** Fixed cleanup to remove both edit-prompt element and meta edge
3. **Positioning:** Improved to use edge midpoint instead of click position

Closes #29

Generated with [Claude Code](https://claude.ai/code)