### PR TITLE
Add Vercel preview debug features for validation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,16 @@
   <script src="https://cdn.jsdelivr.net/npm/eruda"></script>
   <script>eruda.init();</script>
 
-  <button id="drillUp">↑ Drill Up</button>
+  <!-- Debug banner for Vercel preview validation -->
+  <div id="debug-banner" style="position: fixed; top: 0; left: 0; right: 0; background: #00aaff; color: white; padding: 8px; text-align: center; font-size: 14px; z-index: 9999; font-weight: bold;">
+    🚀 Vercel Preview - Build: <span id="build-timestamp"></span>
+  </div>
+  <script>
+    document.getElementById('build-timestamp').textContent = new Date().toISOString();
+    console.log('[VERCEL-PREVIEW] Debug banner loaded at:', new Date().toISOString());
+  </script>
+
+  <button id="drillUp" style="top: 48px;">↑ Drill Up</button>
 
   <div id="canvas" mode="navigate">
     <svg id="edges-layer"></svg>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1289,6 +1289,12 @@ function updateCanvasController(controller: CanvasController) {
 }
 
 (async function main() {
+    // Vercel Preview Debug - Issue #30
+    console.log('🚀 [VERCEL-PREVIEW] Application initialized');
+    console.log('🚀 [VERCEL-PREVIEW] Timestamp:', new Date().toISOString());
+    console.log('🚀 [VERCEL-PREVIEW] User Agent:', navigator.userAgent);
+    console.log('🚀 [VERCEL-PREVIEW] URL:', window.location.href);
+
     const params = new URLSearchParams(window.location.search);
     const canvasId = params.get("canvas") || "canvas-002";
     const token = params.get("token");
@@ -1300,4 +1306,6 @@ function updateCanvasController(controller: CanvasController) {
     };
     rootCanvasState = await loadInitialCanvas(rootCanvasState, token);
     updateCanvasController(new CanvasController(rootCanvasState));
+
+    console.log('🚀 [VERCEL-PREVIEW] Canvas controller ready');
 })();


### PR DESCRIPTION
## Summary
This PR adds debug features to enable validation of the Vercel preview iteration workflow.

### Changes
- ✨ Added visible blue debug banner with build timestamp at the top of the page
- 📝 Added console logging with `[VERCEL-PREVIEW]` prefix for easy identification
- 🎨 Adjusted "Drill Up" button position to accommodate the debug banner

### Validation with Playwright
The debug features can be validated using Playwright MCP tools:
1. **Visual validation**: Check for the presence of the debug banner element (`#debug-banner`)
2. **Console validation**: Verify console logs contain `[VERCEL-PREVIEW]` messages
3. **Timestamp validation**: Confirm build timestamp is displayed

### Test Plan
1. Deploy to Vercel preview
2. Use Playwright to navigate to the preview URL
3. Verify debug banner is visible
4. Check console logs for `[VERCEL-PREVIEW]` messages

Fixes #30

---
🤖 Generated with [Claude Code](https://claude.ai/code)