### PR TITLE
fix: prevent iOS mobile zoom from corrupting canvas interactions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=overlays-content">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=overlays-content">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/src/lib/gesture-machine/pointerAdapter.ts
+++ b/src/lib/gesture-machine/pointerAdapter.ts
@@ -2,6 +2,41 @@
 // Thin DOM ⇆ FSM bridge.
 // Converts native pointer / wheel events into *pure* FSM events.
 // ----------------------------------------------------------------------------
+
+/**
+ * Get the visual viewport scale (iOS Safari native zoom level).
+ * Returns 1 if no zoom or visualViewport API unavailable.
+ */
+function getVisualViewportScale(): number {
+  return window.visualViewport?.scale ?? 1;
+}
+
+/**
+ * Adjust client coordinates to compensate for iOS native browser zoom.
+ * When iOS triggers native zoom, clientX/clientY are in visual viewport coords
+ * but we need layout viewport coords for consistent canvas calculations.
+ */
+function adjustForVisualViewport(clientX: number, clientY: number): { x: number; y: number } {
+  const vvScale = getVisualViewportScale();
+  if (vvScale === 1) {
+    return { x: clientX, y: clientY };
+  }
+
+  // Compensate for visual viewport zoom
+  const vv = window.visualViewport;
+  if (vv) {
+    // The visual viewport offset tells us how much the viewport has panned
+    const offsetX = vv.offsetLeft;
+    const offsetY = vv.offsetTop;
+    return {
+      x: (clientX + offsetX * vvScale) / vvScale,
+      y: (clientY + offsetY * vvScale) / vvScale
+    };
+  }
+
+  return { x: clientX / vvScale, y: clientY / vvScale };
+}
+
 export function installPointerAdapter(
   rootEl: HTMLElement,
   service: any,
@@ -15,6 +50,9 @@ export function installPointerAdapter(
   let lastTap: { t: number; x: number; y: number } = { t: 0, x: 0, y: 0 };
   const TAP_MS = 300;
   const TAP_DIST = 10;
+
+  // Track if visual viewport zoom is active (iOS native zoom corruption)
+  let lastKnownVVScale = 1;
 
   const classifyHandle = (node: Element | null): string | null => {
     if (!node) return null;
@@ -36,7 +74,11 @@ export function installPointerAdapter(
   };
 
   const send = (type: string, ev: PointerEvent | WheelEvent | KeyboardEvent, extra: Record<string, any> = {}): void => {
-    const xy = { x: (ev as any).clientX || 0, y: (ev as any).clientY || 0 };
+    // Adjust coordinates for iOS visual viewport zoom
+    const rawX = (ev as any).clientX || 0;
+    const rawY = (ev as any).clientY || 0;
+    const xy = adjustForVisualViewport(rawX, rawY);
+
     const elementNode = (ev.target as Element)?.closest('.canvas-element');
     const handleNode = (ev.target as Element)?.closest('.element-handle');
     const edgeLabelNode = (ev.target as Element)?.closest('text[data-id]');
@@ -61,7 +103,20 @@ export function installPointerAdapter(
 
   const onPointerDown = (ev: PointerEvent): void => {
     ev.preventDefault();
-    active.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+
+    // Check for iOS visual viewport zoom corruption
+    const currentVVScale = getVisualViewportScale();
+    if (currentVVScale !== 1 && currentVVScale !== lastKnownVVScale) {
+      console.warn('[PointerAdapter] iOS native zoom detected, scale:', currentVVScale);
+      // Clear any stale pointer state from corrupted zoom session
+      active.clear();
+    }
+    lastKnownVVScale = currentVVScale;
+
+    // Store adjusted coordinates in active map
+    const adjusted = adjustForVisualViewport(ev.clientX, ev.clientY);
+    active.set(ev.pointerId, adjusted);
+
     const handleNode = (ev.target as Element)?.closest('.element-handle');
     const edgeLabelNode = (ev.target as Element)?.closest('text[data-id]');
     const elementNode = (ev.target as Element)?.closest('.canvas-element');
@@ -93,7 +148,9 @@ export function installPointerAdapter(
 
   const onPointerMove = (ev: PointerEvent): void => {
     if (!active.has(ev.pointerId)) return;
-    active.set(ev.pointerId, { x: ev.clientX, y: ev.clientY });
+    // Store adjusted coordinates in active map
+    const adjusted = adjustForVisualViewport(ev.clientX, ev.clientY);
+    active.set(ev.pointerId, adjusted);
     cancelLongPress();
     send('POINTER_MOVE', ev);
   };
@@ -108,15 +165,16 @@ export function installPointerAdapter(
 
     send('POINTER_UP', ev);
 
-    /*  tap / double-tap detection  */
+    /*  tap / double-tap detection - use adjusted coordinates */
     if (ev.button === 0) {
+      const adjusted = adjustForVisualViewport(ev.clientX, ev.clientY);
       const dt = ev.timeStamp - lastTap.t;
-      const dist = Math.hypot(ev.clientX - lastTap.x, ev.clientY - lastTap.y);
+      const dist = Math.hypot(adjusted.x - lastTap.x, adjusted.y - lastTap.y);
       if (dt < TAP_MS && dist < TAP_DIST) {
         send('DOUBLE_TAP', ev);
         lastTap.t = 0; // reset
       } else {
-        lastTap = { t: ev.timeStamp, x: ev.clientX, y: ev.clientY };
+        lastTap = { t: ev.timeStamp, x: adjusted.x, y: adjusted.y };
       }
     }
   };
@@ -147,6 +205,33 @@ export function installPointerAdapter(
   window.addEventListener('keydown', onKeydown, { passive: true });
   window.addEventListener('keyup', onKeyup, { passive: true });
 
+  /* iOS Safari gesture event prevention - these trigger native zoom */
+  const preventGesture = (e: Event) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+  document.addEventListener('gesturestart', preventGesture, { passive: false });
+  document.addEventListener('gesturechange', preventGesture, { passive: false });
+  document.addEventListener('gestureend', preventGesture, { passive: false });
+
+  /* Visual viewport zoom detection and recovery */
+  const onVisualViewportResize = () => {
+    const scale = getVisualViewportScale();
+    if (scale !== 1) {
+      console.warn('[PointerAdapter] Visual viewport zoom detected:', scale, '- clearing pointer state');
+      // Clear pointer state to prevent corrupted interactions
+      active.clear();
+      capturedTargets.clear();
+      // Notify controller to potentially reset
+      const controller = service.state?.context?.controller;
+      if (controller?.onVisualViewportZoom) {
+        controller.onVisualViewportZoom(scale);
+      }
+    }
+    lastKnownVVScale = scale;
+  };
+  window.visualViewport?.addEventListener('resize', onVisualViewportResize);
+
   /* teardown helper */
   return () => {
     rootEl.removeEventListener('pointerdown', onPointerDown);
@@ -156,5 +241,9 @@ export function installPointerAdapter(
     rootEl.removeEventListener('wheel', onWheel);
     window.removeEventListener('keydown', onKeydown);
     window.removeEventListener('keyup', onKeyup);
+    document.removeEventListener('gesturestart', preventGesture);
+    document.removeEventListener('gesturechange', preventGesture);
+    document.removeEventListener('gestureend', preventGesture);
+    window.visualViewport?.removeEventListener('resize', onVisualViewportResize);
   };
 }

--- a/src/main.css
+++ b/src/main.css
@@ -1,11 +1,20 @@
+/* iOS zoom prevention - apply to all elements */
+* {
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
 html,
 body {
     margin: 0;
     padding: 0;
     overflow: hidden;
     height: 100%;
+    width: 100%;
     user-select: none;
+    -webkit-user-select: none;
     touch-action: none;
+    -ms-touch-action: none;
     font-family: sans-serif;
     background-color: white;
     position: fixed;
@@ -14,6 +23,9 @@ body {
     right: 0;
     bottom: 0;
     --highlight: #00aaff;
+    /* Prevent iOS text size adjustment which can trigger zoom */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 #canvas {
@@ -352,6 +364,9 @@ body {
     height: 100%;
     overflow: auto;
     background-color: rgba(0, 0, 0, 0.7);
+    /* Prevent iOS zoom when interacting with modal */
+    touch-action: pan-y;
+    -webkit-overflow-scrolling: touch;
 }
 
 .modal-content {

--- a/src/main.ts
+++ b/src/main.ts
@@ -504,6 +504,20 @@ class CanvasController {
         this.updateGroupBox()
     }
 
+    /**
+     * Called when iOS visual viewport zoom is detected.
+     * This can corrupt pointer coordinates and interaction state.
+     */
+    onVisualViewportZoom(scale: number) {
+        console.warn('[CanvasController] iOS visual viewport zoom detected:', scale);
+        // Clear selection to reset interaction state
+        this.selectedElementIds.clear();
+        this.updateGroupBox();
+        this.hideContextMenu();
+        // Re-render to ensure clean state
+        this.requestRender();
+    }
+
     recenterOnElement(elId: string) {
         const el = this.findElementById(elId);
         if (!el) {


### PR DESCRIPTION
- Add visual viewport scale detection and coordinate compensation
- Block iOS gesture events (gesturestart/change/end) that trigger native zoom
- Monitor visualViewport.resize to detect and recover from zoom state
- Add CSS hardening (-webkit-touch-callout, -webkit-tap-highlight-color)
- Add onVisualViewportZoom handler to CanvasController for state recovery
- Enhance viewport meta with minimum-scale=1 and viewport-fit=cover

When iOS Safari triggers native browser zoom, pointer coordinates become misaligned between visual and layout viewports. This fix compensates for the offset and clears corrupted state when zoom is detected.

https://claude.ai/code/session_01KdBtkkZ4w7KUGo3yYTvr9P